### PR TITLE
feat: add queue helper

### DIFF
--- a/rwf/src/job/mod.rs
+++ b/rwf/src/job/mod.rs
@@ -11,5 +11,5 @@ pub mod worker;
 pub use clock::Clock;
 pub use cron::Cron;
 pub use error::Error;
-pub use model::{Job, JobHandler, JobModel};
+pub use model::{queue, queue_delay, Job, JobHandler, JobModel};
 pub use worker::Worker;


### PR DESCRIPTION
Simplify queueing jobs

```rs
use rwf::job::queue;
use crate::jobs::SendWelcomeJob;

let job = SendWelcomeJob {
    email: "foo@example.com".into(),
};

queue(&job).await?;
 ```