### PR TITLE
Openapi

### DIFF
--- a/examples/openapi/README.md
+++ b/examples/openapi/README.md
@@ -9,7 +9,7 @@ Rwf offers an Option to auto generate OpenApi Specs for the CRUD handler (contro
 
 ### `ModelController` with OpenApi Specs
 
-The `ModelController` trait works with Rwf's ORM models and automatically (de)serializes API inputs/outputs and fetches and updates database records.
+The `ModelController` trait works with Rf's ORM models and automatically (de)serializes API inputs/outputs and fetches and updates database records.
 
 ```rust
 #[generate_openapi_model_controller(i64, User)]
@@ -22,7 +22,7 @@ impl ModelController for UsersController {
 }
 ```
 
-The model needs to be serializable into and from JSON, so make sure to derive the appropriate serde traits.
+The model needs to be serializable into and from JSON, so make sure to derive the appropriate Serde traits.
 The Model needs to implement the `ToSchema` and `ToResponse` trait to let Rwf generate the appropriate Specs:
 
 ```rust
@@ -63,11 +63,11 @@ async fn main() {
 
 The `crud` method will automatically implement the following routes:
 
-| Path | Method | Description                                                                                            |
-|------|--------|--------------------------------------------------------------------------------------------------------|
-| `/api/users` | GET    | List all users. Supports pagination, e.g. `?page_size=25&page=1`. Default page size is 25.             |
+| Path             | Method | Description                                                                                            |
+|------------------|--------|--------------------------------------------------------------------------------------------------------|
+| `/api/users`     | GET    | List all users. Supports pagination, e.g. `?page_size=25&page=1`. Default page size is 25.             |
 | `/api/users/:id` | GET    | Fetch a user by primary key.                                                                           |
-| `/api/users`| POST   | Create a new user. All fields not marked optional or not having serde-specified defaults are required. |
+| `/api/users`     | POST   | Create a new user. All fields not marked optional or not having serde-specified defaults are required. |
 | `/api/users/:id` | PUT    | Update a user. Same requirement for fields as the create method above.                                 |
 | `/api/users/:id` | PATCH  | Update a user. Only the fields that have changed can be supplied.                                      |
 | `/api/users/:id` | DELETE | Delete a user by primary key                                                                           |
@@ -82,4 +82,54 @@ $ curl localhost:8000/api/users -d '{"email": "test@test.com"}' -w '\n'
 {"id":1, email":"test@test.com","created_at":"+002024-10-09T22:59:10.693321000Z","admin":false}
 $ curl localhost:8000/openapi/yaml 
 APISPECS
+```
+
+### OpenApi for `Controller` and `PageController`
+
+You can also generate OpenApi Specs for other Controllers. To do so you have to use the 
+'macros::generate_openapi_specs' Attribute Macro. For a `Controller` this will create Specs for the get method, For a `PageController` this would create get and/or post Specs (depending on which methods are implemented).
+
+```rust
+use rwf::http::{Request, Response};
+use rwf::controller::{Controller, Error};
+#[derive(Default)]
+struct TestController;
+
+#[rwf::macros::generate_openapi_specs]
+#[async_trait]
+impl Controller for TestController {
+    async fn handle(&self, request: &Request) -> Result<Response, Error> {
+        // Creates a text/plain content-typed ApiSpec
+        if some_condition() {
+            Ok(Response::new().text("..."))
+        } else if other_condition() {
+            // Creates an additional text/html content-type ApiSpec
+            Response::new().html("...")
+        } else {
+            // Creates a Redirect Spec
+            Response::new().redirect("...")
+        }
+    }
+}
+```
+
+It is also possible to give a TypeHint for JSON Responses
+
+```rust
+#[derive(Serialize, Deserialize. ToSchema, ToResponse)]
+struct Body {
+    data: String,
+    number: i64
+}
+#[derive(Default)]
+struct TestController;
+
+#[rwf::macros::generate_openapi_specs(Body)]
+#[async_trait]
+impl Controller for TestController {
+    async fn handle(&self, request: &Request) -> Result<Response, Error> {
+        // Create a JSON Response and set it to `Body` in the Specs
+        Ok(Response::new().json(Body{data: "TestString".to_string(), number: 1})?)
+    }
+}
 ```

--- a/examples/openapi/src/main.rs
+++ b/examples/openapi/src/main.rs
@@ -1,6 +1,6 @@
 use rwf::controller::middleware::SecureId;
 use rwf::controller::{Middleware, MiddlewareSet, ModelController, OpenApiController};
-use rwf::macros::generate_openapi_model_controller;
+use rwf::macros::{generate_openapi_model_controller, generate_openapi_specs};
 use rwf::model::migrate;
 use rwf::prelude::*;
 
@@ -35,6 +35,49 @@ impl Default for ProductController {
     }
 }
 
+#[derive(macros::Form, macros::TemplateValue, Clone)]
+struct PageForm {
+    data: String,
+}
+
+#[derive(Default, macros::PageController)]
+struct PageFormController;
+
+/// Try to generate OpenApi Specs for non ModelController
+#[generate_openapi_specs]
+#[async_trait]
+impl PageController for PageFormController {
+    async fn get(&self, request: &Request) -> Result<Response, Error> {
+        render!(request, "templates/page.html")
+    }
+    async fn post(&self, request: &Request) -> Result<Response, Error> {
+        let data: PageForm = request.form()?;
+        let stream = turbo_stream!(request, "templates/page_element.html", "list", "elem" => data)
+            .action("append");
+        Ok(Response::new().turbo_stream(&[stream]))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, ToResponse)]
+struct Body {
+    data: String,
+    ts: OffsetDateTime,
+}
+#[derive(Default)]
+struct BodyController;
+
+#[generate_openapi_specs(Body)]
+#[async_trait]
+impl Controller for BodyController {
+    async fn handle(&self, request: &Request) -> Result<Response, Error> {
+        let body = Body {
+            data: serde_json::to_string(&request.head())?,
+            ts: OffsetDateTime::now_utc(),
+        };
+        Ok(Response::new().json(body)?)
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), rwf::http::Error> {
     migrate().await?;
@@ -45,10 +88,21 @@ async fn main() -> Result<(), rwf::http::Error> {
     // Create a handler without the overwrite of the id field
     //let apictrl = ProductController {middleware: MiddlewareSet::default()}.crud("/prod");
 
+    // Generate PageController with ApiSpecs for get and post Mehthods
+    let page = route!("/page" => PageFormController);
     // Makes the OpenApi Specs available under /openapi/yaml or /openapi/json
     // Serve an API Browser under /openapi/redoc and /openapi/rapidoc
     let openapi = route!("/openapi" => OpenApiController);
 
-    let routes = vec![apictrl, openapi];
+    // Generate a Controller with ApiSpecs and a hint for the Json Type!
+    let bodyctrl = route!("/body" => BodyController);
+
+    let routes = vec![
+        apictrl,
+        page,
+        openapi,
+        bodyctrl,
+        route!("/turbo_stream" => rwf::controller::TurboStream),
+    ];
     rwf::http::Server::new(routes).launch().await
 }

--- a/examples/openapi/templates/page.html
+++ b/examples/openapi/templates/page.html
@@ -1,0 +1,20 @@
+<html>
+    <head>
+        <title>OpenApi TestPage</title>
+        <%= rwf_head %>
+    </head>
+    <body>
+    <%= rwf_turbo_stream("/turbo-stream") %>
+        <ul id="list">
+
+        </ul>
+        <div>
+            <form method="post">
+                <%= csrf_token %>
+                <label for="data">Neues Element: </label>
+                <input id="data" type="text" name="data">
+                <input type="submit" value="Send">
+            </form>
+        </div>
+    </body>
+</html>

--- a/examples/openapi/templates/page_element.html
+++ b/examples/openapi/templates/page_element.html
@@ -1,0 +1,1 @@
+<li><%= elem.data %></li>

--- a/rwf-macros/src/lib.rs
+++ b/rwf-macros/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 
 use syn::{
     parse, parse_macro_input, parse_quote, punctuated::Punctuated, Attribute, Data, DeriveInput,
-    Expr, ItemFn, Meta, ReturnType, Token, Type, Visibility,
+    Expr, ItemFn, ItemImpl, Meta, ReturnType, Token, Type, Visibility,
 };
 
 use quote::{quote, ToTokens};
@@ -748,6 +748,17 @@ pub fn controller(_args: TokenStream, input: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+#[proc_macro_attribute]
+pub fn generate_openapi_specs(args: TokenStream, input: TokenStream) -> TokenStream {
+    let controller = parse_macro_input!(input as ItemImpl);
+    if args.is_empty() {
+        openapi::generate_api_specs_controller(controller, None).into()
+    } else {
+        let json_type = parse_macro_input!(args as Type);
+        openapi::generate_api_specs_controller(controller, Some(json_type)).into()
+    }
 }
 
 #[proc_macro_attribute]

--- a/rwf-macros/src/lib.rs
+++ b/rwf-macros/src/lib.rs
@@ -279,7 +279,7 @@ fn handle_overrides(attributes: &[Attribute]) -> proc_macro2::TokenStream {
 /// This implements mappings between the `Controller`
 /// trait and the struct implementing
 /// the `PageController` trait.
-#[proc_macro_derive(PageController, attributes(auth, middleware, skip_csrf))]
+#[proc_macro_derive(PageController, attributes(auth, middleware, skip_csrf, openapi))]
 pub fn derive_page_controller(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let overrides = handle_overrides(&input.attrs);
@@ -297,6 +297,9 @@ pub fn derive_page_controller(input: TokenStream) -> TokenStream {
 
             async fn handle(&self, request: &rwf::http::Request) -> Result<rwf::http::Response, rwf::controller::Error> {
                 rwf::controller::PageController::handle(self, request).await
+            }
+            fn route(self, path: &str) -> rwf::http::Handler {
+                rwf::controller::PageController::route(self, path)
             }
         }
     }.into()
@@ -543,7 +546,7 @@ pub fn route(input: TokenStream) -> TokenStream {
     let controller = iter.next().unwrap();
 
     quote! {
-        #controller::default().route(#route)
+        rwf::controller::Controller::route(#controller::default(), #route)
     }
     .into()
 }

--- a/rwf-macros/src/openapi.rs
+++ b/rwf-macros/src/openapi.rs
@@ -1,11 +1,350 @@
-use proc_macro2::{Ident, Span};
+use crate::snake_case;
+use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
 use quote::{format_ident, ToTokens};
-
-use crate::snake_case;
+use std::fmt::Debug;
+use std::str::FromStr;
 use syn::parse::{Parse, ParseStream};
-use syn::{parse_quote, ItemStruct, LitStr, Token, Type};
+use syn::{
+    parse_quote, Expr, ExprMethodCall, ImplItem, ItemStruct, Lit, LitStr, Stmt, Token, Type,
+};
+#[allow(unused)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ResponseTypes {
+    HTML,
+    JSON,
+    TEXT,
+    TURBO,
+    NotImplemented,
+    NotFound,
+    Forbidden,
+    BadRequest,
+    Redirect,
+}
 
+impl ResponseTypes {
+    fn default_code(&self) -> u16 {
+        match self {
+            ResponseTypes::HTML => 200,
+            ResponseTypes::JSON => 200,
+            ResponseTypes::TEXT => 200,
+            ResponseTypes::TURBO => 200,
+            ResponseTypes::NotImplemented => 501,
+            ResponseTypes::NotFound => 404,
+            ResponseTypes::Forbidden => 403,
+            ResponseTypes::BadRequest => 400,
+            ResponseTypes::Redirect => 302,
+        }
+    }
+}
+#[derive(Default)]
+struct ResponseBuilder {
+    ty: Option<ResponseTypes>,
+    code: Option<Lit>,
+}
+struct Response {
+    ty: ResponseTypes,
+    code: Lit,
+    json: Option<Type>,
+}
+impl From<ResponseTypes> for Response {
+    fn from(value: ResponseTypes) -> Self {
+        let code = Lit::new(Literal::from_str(value.default_code().to_string().as_str()).unwrap());
+        Self {
+            ty: value,
+            code,
+            json: None,
+        }
+    }
+}
+impl ResponseBuilder {
+    fn build(self) -> Response {
+        if self.ty.is_none() {
+            panic!("Failed to Infer Response type")
+        }
+        let ty = self.ty.unwrap();
+        if self.code.is_some() {
+            Response {
+                ty,
+                code: self.code.unwrap(),
+                json: None,
+            }
+        } else {
+            Response::from(ty)
+        }
+    }
+}
+
+impl ToTokens for ResponseTypes {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            ResponseTypes::HTML => quote! {content_type="text/html", description="A HTML Response"},
+            ResponseTypes::JSON => {
+                quote! {content_type="application/json", description="A JSON Response"}
+            }
+            ResponseTypes::TEXT => {
+                quote! {content_type="text/plain", description="A Text Response"}
+            }
+            ResponseTypes::TURBO => {
+                quote! {content_type="text/vnd.turbo-stream.html", description="A Turbo Response"}
+            }
+            ResponseTypes::NotFound => quote! {description="Requested Content was not found"},
+            ResponseTypes::Forbidden => quote! {description="Request is forbidden"},
+            ResponseTypes::BadRequest => quote! {description="Bad Request"},
+            ResponseTypes::Redirect => quote! {description="Redirect to another location"},
+            ResponseTypes::NotImplemented => {
+                quote! {description="The endpoint is not implemented yet"}
+            }
+        }
+        .to_tokens(tokens);
+    }
+}
+
+impl ToTokens for Response {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let code = self.code.clone();
+        let ty = self.ty.clone();
+        let json = if let Some(json) = self.json.as_ref() {
+            quote! {, body=#json}
+        } else {
+            TokenStream::new()
+        };
+        quote! {
+            (status = #code, #ty #json)
+        }
+        .to_tokens(tokens);
+    }
+}
+
+fn parse_method_chain(call: &ExprMethodCall, builder: &mut ResponseBuilder) {
+    // eprintln!("METHOD CALL: {} - {}", call.receiver.to_token_stream(), call.method.to_token_stream());
+    let receiver = call.receiver.to_token_stream().to_string();
+    let method = call.method.to_token_stream().to_string();
+    if receiver.starts_with("Response") {
+        if method.eq("html") {
+            builder.ty = Some(ResponseTypes::HTML);
+        } else if method.eq("text") {
+            builder.ty = Some(ResponseTypes::TEXT);
+        } else if method.eq("turbo_stream") {
+            builder.ty = Some(ResponseTypes::TURBO);
+        } else if method.eq("json") {
+            builder.ty = Some(ResponseTypes::JSON);
+        } else if method.eq("code") {
+            if let Some(Expr::Lit(code)) = call.args.iter().next() {
+                builder.code = Some(code.lit.clone())
+            }
+        } else if method.eq("redirect") {
+            builder.ty = Some(ResponseTypes::Redirect)
+        }
+        if let Expr::MethodCall(expr) = call.receiver.as_ref() {
+            parse_method_chain(expr, builder);
+        }
+    }
+}
+fn parse_call(expr: &Expr, acc: &mut Vec<Response>) {
+    if let Expr::Call(call) = expr {
+        //eprintln!("CALL: {} - {}", call.func.to_token_stream(), call.args.to_token_stream());
+        let func = call.func.to_token_stream().to_string();
+        if func == "Ok" {
+            if call.args.len() == 1 {
+                return parse_call(call.args.iter().next().unwrap(), acc);
+            }
+        } else if func.starts_with("Response") {
+            if func.contains("not_implemented") {
+                acc.push(Response::from(ResponseTypes::NotImplemented))
+            } else if func.contains("not_found") {
+                acc.push(Response::from(ResponseTypes::NotFound))
+            } else if func.contains("bad_request") {
+                acc.push(Response::from(ResponseTypes::BadRequest))
+            }
+        }
+    } else if let Expr::MethodCall(call) = expr {
+        let mut builder = ResponseBuilder::default();
+        parse_method_chain(call, &mut builder);
+        if !builder.ty.is_none() {
+            acc.push(builder.build());
+        }
+    } else if let Expr::If(expr_if) = expr {
+        parse_block(expr_if.then_branch.stmts.clone(), acc);
+        if let Some(ref else_expr) = expr_if.else_branch {
+            return parse_call(else_expr.1.as_ref(), acc);
+        }
+    } else if let Expr::Block(block) = expr {
+        parse_block(block.block.stmts.clone(), acc)
+    } else if let Expr::Return(retexpr) = expr {
+        if let Some(expr) = retexpr.expr.as_ref() {
+            parse_call(expr, acc)
+        }
+    } else if let Expr::Try(expr_try) = expr {
+        parse_call(expr_try.expr.as_ref(), acc)
+    } else if let Expr::Macro(expr_macro) = expr {
+        if expr_macro.mac.path.is_ident("render") {
+            acc.push(Response::from(ResponseTypes::HTML))
+        } else if expr_macro.mac.path.is_ident("turbo_stream") {
+            acc.push(Response::from(ResponseTypes::TURBO))
+        }
+    }
+}
+
+fn parse_block(stmts: Vec<Stmt>, acc: &mut Vec<Response>) {
+    for stmt in stmts {
+        // eprintln!("{}", stmt.to_token_stream());
+        if let Stmt::Expr(expr, ..) = stmt {
+            parse_call(&expr, acc);
+        }
+        // eprintln!();
+    }
+}
+
+pub fn generate_api_specs_controller(
+    mut input: syn::ItemImpl,
+    json: Option<Type>,
+) -> proc_macro2::TokenStream {
+    let mut outputt = proc_macro2::TokenStream::new();
+    let mut fnames = Vec::new();
+
+    let mut visited = false;
+
+    let apiname = format_ident!("{}ApiDoc", input.self_ty.to_token_stream().to_string());
+
+    for item in input.items.clone() {
+        if let ImplItem::Fn(fnimpl) = item {
+            if ["handle", "list", "get", "post", "delete", "put", "patch"]
+                .contains(&fnimpl.sig.ident.to_string().as_str())
+            {
+                let (method, path) = if let Some((_, pth, _)) = input.trait_.clone() {
+                    if pth.is_ident("Controller") {
+                        if !visited {
+                            input.items.push(parse_quote!{
+                                fn route(self, path: &str) -> Handler
+                                where Self: Sized + 'static,
+                                {
+                                    let mut spec = #apiname :: openapi() ;
+                                    <dyn rwf::controller::Controller>::modify(&self, &mut spec);
+                                    rwf::controller::openapi::registrer_controller(path.to_string(), spec);
+                                    Handler::route(path, self)
+                                }
+                            });
+                            input.to_tokens(&mut outputt);
+                            visited = true;
+                        }
+                        (format_ident!("get"), LitStr::new("/", Span::call_site()))
+                    } else if pth.is_ident("PageController") {
+                        if fnimpl.sig.ident.ne("handle") {
+                            if !visited {
+                                input.items.push(parse_quote!{
+                                fn route(self, path: &str) -> Handler
+                                where Self: Sized + 'static,
+                                {
+                                    let mut spec = #apiname :: openapi() ;
+                                    <dyn rwf::controller::Controller>::modify(&self, &mut spec);
+                                    rwf::controller::openapi::registrer_controller(path.to_string(), spec);
+                                    Handler::route(path, self)
+                                }
+                            });
+                                input.to_tokens(&mut outputt);
+                                visited = true;
+                            }
+                            (
+                                fnimpl.sig.ident.clone(),
+                                LitStr::new("/", Span::call_site()),
+                            )
+                        } else {
+                            continue;
+                        }
+                    } else if pth.is_ident("RestController") {
+                        if !visited {
+                            input.items.push(parse_quote!{
+                                fn rest(self, path: &str) -> Handler
+                                where Self: Sized + 'static,
+                                {
+                                    let mut spec = #apiname :: openapi() ;
+                                    <dyn rwf::controller::Controller>::modify(&self, &mut spec);
+                                    rwf::controller::openapi::registrer_controller(path.to_string(), spec);
+                                    Handler::rest(path, self)
+                                }
+                            });
+                            input.to_tokens(&mut outputt);
+                            visited = true;
+                        }
+                        if fnimpl.sig.ident.eq("handle") {
+                            continue;
+                        } else if fnimpl.sig.ident.eq("list") {
+                            (format_ident!("get"), LitStr::new("/", Span::call_site()))
+                        } else if fnimpl.sig.ident.eq("post") {
+                            (format_ident!("post"), LitStr::new("/", Span::call_site()))
+                        } else {
+                            (
+                                fnimpl.sig.ident.clone(),
+                                LitStr::new("/{id}", Span::call_site()),
+                            )
+                        }
+                    } else {
+                        continue;
+                    }
+                } else {
+                    continue;
+                };
+                let mut acc = Vec::new();
+                parse_block(fnimpl.block.stmts, &mut acc);
+                if !acc.is_empty() {
+                    let controller = input.self_ty.clone();
+                    let ident = fnimpl.sig.ident.clone();
+                    let fnname = format_ident!(
+                        "{}_{}",
+                        snake_case(controller.to_token_stream().to_string().as_str()),
+                        ident
+                    );
+                    for res in acc.iter_mut() {
+                        if ResponseTypes::JSON == res.ty {
+                            res.json = json.clone()
+                        }
+                    }
+                    let generate = quote! {
+                        #[rwf::prelude::utoipa::path(
+                            #method,
+                            path=#path,
+                            responses(
+                                #(
+                                    #acc
+                                ),*
+                            )
+                        )]
+                        fn #fnname(request: &Request) -> Result<Response, rwf::controller::Error> {
+                            Ok(Response::not_implemented())
+                        }
+                    };
+                    generate.to_tokens(&mut outputt);
+                    fnames.push(fnname);
+                }
+            }
+        }
+    }
+    let components = if let Some(json) = json {
+        quote! {
+            components(
+                schemas(#json),
+                responses(#json)
+            ),
+        }
+    } else {
+        proc_macro2::TokenStream::new()
+    };
+    quote! {
+        #[derive(rwf::prelude::OpenApi)]
+        #[openapi(
+            #components
+            paths(
+                #(
+                    #fnames
+                ),*
+            )
+        )]
+        struct #apiname;
+    }
+    .to_tokens(&mut outputt);
+    outputt
+}
 pub fn generate_controller4(
     mut input: ItemStruct,
     targs: TypeParserInput,

--- a/rwf-tests/src/main.rs
+++ b/rwf-tests/src/main.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code)]
 use rwf::crypto::encrypt_number;
-use rwf::model::{get_connection, Column, Model, Pool, Value};
+use rwf::model::{Column, Model, Pool, Value};
 use rwf::view::Templates;
 use rwf::{
+    controller::oidc::{OidcAuthentication, OidcController},
     controller::{AuthHandler, SessionId, StaticFiles, WebsocketController},
     http::{Request, Response, Server, Stream},
     job::Job,
@@ -22,38 +23,12 @@ mod controllers;
 pub mod models;
 
 use crate::models::CreateUserCallback;
-use models::{Order, OrderItem, Product, User};
+use models::{OidcUser, Order, OrderItem, Product, User};
 
 use rwf::controller::middleware::SecureId;
-use rwf::controller::oidc::{OidcUser as OUser, *};
 use rwf::controller::{
     AllowAll, BasicAuth, Middleware, MiddlewareSet, OpenApiController, RateLimiter,
 };
-use rwf::http::Handler;
-
-#[derive(Debug, Clone, Serialize, Deserialize, macros::Model, ToSchema, ToResponse)]
-struct OidcUser {
-    #[schema(minimum = 1, example = 128, format = "Int16")]
-    id: Option<i16>,
-    #[schema(format = "uuid", example = "750590ca-ee80-11f0-92ed-2218e57cbd42")]
-    sub: Uuid,
-    #[schema(example = "john")]
-    name: String,
-    #[schema(format = "email", example = "john@mail.tld")]
-    email: String,
-    #[schema(
-        format = "password",
-        example = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIzSi13U0FRSWNscThXSkxLdEY1NzIxVWY3ZVp5VEZBV3JUdzVtZXFwTnZjIn0.eyJleHAiOjE3NjgwOTI2OTMsImlhdCI6MTc2ODA5MjM5MywiYXV0aF90aW1lIjoxNzY4MDkyMzkyLCJqdGkiOiJvZnJ0YWM6MmEwZWMyMDAtMWM2Ni0zMzg1LTk5N2ItNDNkNmYyOGE4MTgxIiwiaXNzIjoiaHR0cHM6Ly9zc28uemV1c3JzLm9yZy9yZWFsbXMvb2lkYyIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiI5MzgyZjE5Zi0yYWNjLTQ2ODctYmI4ZC1lNWFkYTliMTdlZWIiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJyd2YiLCJzaWQiOiI5ZDQ5MjE5Zi1mZDFmLTc5NjAtYzk4Yi1kNWFlYWYxZDI2NGUiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xMjcuMC4wLjE6ODAwMCJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiIsImRlZmF1bHQtcm9sZXMtb2lkYyJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwgb2ZmbGluZV9hY2Nlc3MiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsIm5hbWUiOiJTeXN0ZW0gQWRtaW5pc3RyYXRvciIsInByZWZlcnJlZF91c2VybmFtZSI6InN5c2FkbSIsImdpdmVuX25hbWUiOiJTeXN0ZW0iLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJlbWFpbCI6ImFkbWluQHpldXNycy5vcmcifQ.W3fsv2Jf_xhdK061zf2qyW--8bGXLuy-j51Fyti1JcJjV2OYcYlN4uhonH1jlw532dY_7z3_HtosxmLB84tB52JBfm5st3aRmOQG1kuUN23H08AWxoDRr1Ik9e57Wl3gnsc_3grDZgBrGh47YYDZO50U0qC3fF4Dlsp3kFgFhMGOEswNHveC-ic6APJakZH0hgH0UWge5oBJuluHMhrC7nE-pLX7b5M2r_RtcdMmNJlHmidZS4McNjfgH1ShD4bH01WfuYWUKYS5skt_Hx1ga1Eo8F2NpnbwGOSk75jin36luzlA4QpDMhweoqq0I7R1ynEPnP9YGMneAkrnLMhuog"
-    )]
-    access: String,
-    #[schema(
-        format = "password",
-        example = "eyJhbGciOiJIUzUxMiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJkNmY4YWFmYi1lODQ2LTRmZGItOGU0MC01ZDQxOTY5ZDlkNzQifQ.eyJpYXQiOjE3NjgwOTIzOTMsImp0aSI6Ijc2OTJmYjYxLWViYWYtNjk1YS00YjEwLTA0NzQ1ZjJmODEyYiIsImlzcyI6Imh0dHBzOi8vc3NvLnpldXNycy5vcmcvcmVhbG1zL29pZGMiLCJhdWQiOiJodHRwczovL3Nzby56ZXVzcnMub3JnL3JlYWxtcy9vaWRjIiwic3ViIjoiOTM4MmYxOWYtMmFjYy00Njg3LWJiOGQtZTVhZGE5YjE3ZWViIiwidHlwIjoiT2ZmbGluZSIsImF6cCI6InJ3ZiIsInNpZCI6IjlkNDkyMTlmLWZkMWYtNzk2MC1jOThiLWQ1YWVhZjFkMjY0ZSIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwgc2VydmljZV9hY2NvdW50IHJvbGVzIHdlYi1vcmlnaW5zIG9mZmxpbmVfYWNjZXNzIGJhc2ljIGFjciJ9.d0nNel7jTwdQtPRob7Ekq1x5MvWkN3iRCDelw3pTxqH3ZmXPiCT3r024WXrZeswgN7nEdCBvnwDEtgHhV8CuTQ"
-    )]
-    refresh: String,
-    #[schema(format = "datetime", example = "2026-01-11 0:51:33.31944813 +00:00:00")]
-    expire: OffsetDateTime,
-}
 
 #[generate_openapi_model_controller(i16, OidcUser)]
 #[derive(macros::ModelController)]
@@ -67,65 +42,6 @@ impl Default for OidcUserController {
         Self {
             middleware: MiddlewareSet::new(vec![SecureId::default().middleware()]),
         }
-    }
-}
-
-#[async_trait]
-impl OUser for OidcUser {
-    async fn from_token(
-        token: StandardTokenResponse<CoreIdTokenFields, CoreTokenType>,
-        userinfo: UserInfoClaims<EmptyAdditionalClaims, CoreGenderClaim>,
-    ) -> Result<Self, rwf::model::Error> {
-        let name = userinfo
-            .standard_claims()
-            .preferred_username()
-            .unwrap()
-            .to_string();
-        let sub = uuid::Uuid::parse_str(userinfo.standard_claims().subject().to_string().as_str())
-            .unwrap();
-        let email = userinfo.standard_claims().email().unwrap().to_string();
-        let access = token.access_token().secret().clone();
-        let refresh = token.refresh_token().unwrap().secret().clone();
-        let expire = OffsetDateTime::now_utc()
-            .checked_add(Duration::nanoseconds(
-                token.expires_in().unwrap().as_nanos() as i64,
-            ))
-            .unwrap();
-
-        let mut conn = get_connection().await?;
-        OidcUser::find_or_create_by(&[
-            ("name", name.to_value()),
-            ("sub", sub.to_value()),
-            ("email", email.to_value()),
-            ("access", access.to_value()),
-            ("refresh", refresh.to_value()),
-            ("expire", expire.to_value()),
-        ])
-        .unique_by(&["sub"])
-        .fetch(&mut conn)
-        .await
-    }
-    fn access_token(&self) -> AccessToken {
-        AccessToken::new(self.access.clone())
-    }
-    fn refresh_token(&self) -> RefreshToken {
-        RefreshToken::new(self.refresh.clone())
-    }
-    fn expire(&self) -> &OffsetDateTime {
-        &self.expire
-    }
-    fn update_token(
-        mut self,
-        token: StandardTokenResponse<CoreIdTokenFields, CoreTokenType>,
-    ) -> Self {
-        self.access = token.access_token().secret().clone();
-        self.refresh = token.refresh_token().unwrap().secret().clone();
-        self.expire = OffsetDateTime::now_utc()
-            .checked_add(Duration::nanoseconds(
-                token.expires_in().unwrap().as_nanos() as i64,
-            ))
-            .unwrap();
-        self
     }
 }
 
@@ -545,7 +461,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             id: "5".to_string(),
         }
         .route("/base"),
-        BasePlayerController {}.rest("/base/player"),
+        BasePlayerController {}.route("/base/player"),
         route!("/openapi" => OpenApiController),
         engine!("/admin" => engine),
         rwf_admin::static_files()?,

--- a/rwf-tests/src/models/mod.rs
+++ b/rwf-tests/src/models/mod.rs
@@ -1,8 +1,11 @@
 use rwf::async_trait;
+use rwf::controller::oidc::{OidcUser as OUser, *};
 use rwf::model::callbacks::Callback;
-use rwf::model::{Model, Scope};
+use rwf::model::{get_connection, Model, Scope, ToValue};
 use rwf::prelude::{utoipa, Deserialize, Serialize, ToResponse, ToSchema};
 use rwf_macros::Model;
+use time::{Duration, OffsetDateTime};
+use uuid::Uuid;
 
 #[derive(Clone, Model, Debug, PartialEq, Serialize, Deserialize, ToSchema, ToResponse)]
 #[has_many(Order)]
@@ -76,5 +79,88 @@ pub struct Order {
 impl OrderItem {
     pub fn expensive() -> Scope<Self> {
         Self::all().filter_gt("amount", 5.0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Model, ToSchema, ToResponse)]
+pub struct OidcUser {
+    #[schema(minimum = 1, example = 128, format = "Int16")]
+    id: Option<i16>,
+    #[schema(format = "uuid", example = "750590ca-ee80-11f0-92ed-2218e57cbd42")]
+    sub: Uuid,
+    #[schema(example = "john")]
+    name: String,
+    #[schema(format = "email", example = "john@mail.tld")]
+    email: String,
+    #[schema(
+        format = "password",
+        example = "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIzSi13U0FRSWNscThXSkxLdEY1NzIxVWY3ZVp5VEZBV3JUdzVtZXFwTnZjIn0.eyJleHAiOjE3NjgwOTI2OTMsImlhdCI6MTc2ODA5MjM5MywiYXV0aF90aW1lIjoxNzY4MDkyMzkyLCJqdGkiOiJvZnJ0YWM6MmEwZWMyMDAtMWM2Ni0zMzg1LTk5N2ItNDNkNmYyOGE4MTgxIiwiaXNzIjoiaHR0cHM6Ly9zc28uemV1c3JzLm9yZy9yZWFsbXMvb2lkYyIsImF1ZCI6ImFjY291bnQiLCJzdWIiOiI5MzgyZjE5Zi0yYWNjLTQ2ODctYmI4ZC1lNWFkYTliMTdlZWIiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJyd2YiLCJzaWQiOiI5ZDQ5MjE5Zi1mZDFmLTc5NjAtYzk4Yi1kNWFlYWYxZDI2NGUiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xMjcuMC4wLjE6ODAwMCJdLCJyZWFsbV9hY2Nlc3MiOnsicm9sZXMiOlsib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiIsImRlZmF1bHQtcm9sZXMtb2lkYyJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJtYW5hZ2UtYWNjb3VudC1saW5rcyIsInZpZXctcHJvZmlsZSJdfX0sInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwgb2ZmbGluZV9hY2Nlc3MiLCJlbWFpbF92ZXJpZmllZCI6ZmFsc2UsIm5hbWUiOiJTeXN0ZW0gQWRtaW5pc3RyYXRvciIsInByZWZlcnJlZF91c2VybmFtZSI6InN5c2FkbSIsImdpdmVuX25hbWUiOiJTeXN0ZW0iLCJmYW1pbHlfbmFtZSI6IkFkbWluaXN0cmF0b3IiLCJlbWFpbCI6ImFkbWluQHpldXNycy5vcmcifQ.W3fsv2Jf_xhdK061zf2qyW--8bGXLuy-j51Fyti1JcJjV2OYcYlN4uhonH1jlw532dY_7z3_HtosxmLB84tB52JBfm5st3aRmOQG1kuUN23H08AWxoDRr1Ik9e57Wl3gnsc_3grDZgBrGh47YYDZO50U0qC3fF4Dlsp3kFgFhMGOEswNHveC-ic6APJakZH0hgH0UWge5oBJuluHMhrC7nE-pLX7b5M2r_RtcdMmNJlHmidZS4McNjfgH1ShD4bH01WfuYWUKYS5skt_Hx1ga1Eo8F2NpnbwGOSk75jin36luzlA4QpDMhweoqq0I7R1ynEPnP9YGMneAkrnLMhuog"
+    )]
+    access: String,
+    #[schema(
+        format = "password",
+        example = "eyJhbGciOiJIUzUxMiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJkNmY4YWFmYi1lODQ2LTRmZGItOGU0MC01ZDQxOTY5ZDlkNzQifQ.eyJpYXQiOjE3NjgwOTIzOTMsImp0aSI6Ijc2OTJmYjYxLWViYWYtNjk1YS00YjEwLTA0NzQ1ZjJmODEyYiIsImlzcyI6Imh0dHBzOi8vc3NvLnpldXNycy5vcmcvcmVhbG1zL29pZGMiLCJhdWQiOiJodHRwczovL3Nzby56ZXVzcnMub3JnL3JlYWxtcy9vaWRjIiwic3ViIjoiOTM4MmYxOWYtMmFjYy00Njg3LWJiOGQtZTVhZGE5YjE3ZWViIiwidHlwIjoiT2ZmbGluZSIsImF6cCI6InJ3ZiIsInNpZCI6IjlkNDkyMTlmLWZkMWYtNzk2MC1jOThiLWQ1YWVhZjFkMjY0ZSIsInNjb3BlIjoib3BlbmlkIHByb2ZpbGUgZW1haWwgc2VydmljZV9hY2NvdW50IHJvbGVzIHdlYi1vcmlnaW5zIG9mZmxpbmVfYWNjZXNzIGJhc2ljIGFjciJ9.d0nNel7jTwdQtPRob7Ekq1x5MvWkN3iRCDelw3pTxqH3ZmXPiCT3r024WXrZeswgN7nEdCBvnwDEtgHhV8CuTQ"
+    )]
+    refresh: String,
+    #[schema(format = "datetime", example = "2026-01-11 0:51:33.31944813 +00:00:00")]
+    expire: OffsetDateTime,
+}
+
+#[async_trait]
+impl OUser for OidcUser {
+    async fn from_token(
+        token: StandardTokenResponse<CoreIdTokenFields, CoreTokenType>,
+        userinfo: UserInfoClaims<EmptyAdditionalClaims, CoreGenderClaim>,
+    ) -> Result<Self, rwf::model::Error> {
+        let name = userinfo
+            .standard_claims()
+            .preferred_username()
+            .unwrap()
+            .to_string();
+        let sub = uuid::Uuid::parse_str(userinfo.standard_claims().subject().to_string().as_str())
+            .unwrap();
+        let email = userinfo.standard_claims().email().unwrap().to_string();
+        let access = token.access_token().secret().clone();
+        let refresh = token.refresh_token().unwrap().secret().clone();
+        let expire = OffsetDateTime::now_utc()
+            .checked_add(Duration::nanoseconds(
+                token.expires_in().unwrap().as_nanos() as i64,
+            ))
+            .unwrap();
+
+        let mut conn = get_connection().await?;
+        OidcUser::find_or_create_by(&[
+            ("name", name.to_value()),
+            ("sub", sub.to_value()),
+            ("email", email.to_value()),
+            ("access", access.to_value()),
+            ("refresh", refresh.to_value()),
+            ("expire", expire.to_value()),
+        ])
+        .unique_by(&["sub"])
+        .fetch(&mut conn)
+        .await
+    }
+    fn access_token(&self) -> AccessToken {
+        AccessToken::new(self.access.clone())
+    }
+    fn refresh_token(&self) -> RefreshToken {
+        RefreshToken::new(self.refresh.clone())
+    }
+    fn expire(&self) -> &OffsetDateTime {
+        &self.expire
+    }
+    fn update_token(
+        mut self,
+        token: StandardTokenResponse<CoreIdTokenFields, CoreTokenType>,
+    ) -> Self {
+        self.access = token.access_token().secret().clone();
+        self.refresh = token.refresh_token().unwrap().secret().clone();
+        self.expire = OffsetDateTime::now_utc()
+            .checked_add(Duration::nanoseconds(
+                token.expires_in().unwrap().as_nanos() as i64,
+            ))
+            .unwrap();
+        self
     }
 }

--- a/rwf/src/controller/mod.rs
+++ b/rwf/src/controller/mod.rs
@@ -352,6 +352,12 @@ pub trait PageController: Controller {
             Ok(Response::method_not_allowed())
         }
     }
+    fn route(self, path: &str) -> Handler
+    where
+        Self: Sized + 'static,
+    {
+        Handler::route(path, self)
+    }
 }
 
 /// REST controller, which splits requests into 6 REST verbs.

--- a/rwf/src/controller/openapi.rs
+++ b/rwf/src/controller/openapi.rs
@@ -220,6 +220,8 @@ impl OpenApiController {
         for (k, v) in RWF_OPENAPIS.map.read().unwrap().iter() {
             let path = if !k.starts_with("/") {
                 format!("/{}", k)
+            } else if k.eq("/") {
+                "".to_string()
             } else {
                 k.to_string()
             };


### PR DESCRIPTION
Add (experimental) support for OpenApi Spec generation for other Controller Types (Controller, PageController, RestController). This is done by the `generate_openapi_specs` Attribute Macro.

This checks the desired functions (Controller::handle ; PageController::get, PageController::post ; RestController::get, RestController::list, RestController::delete, RestController::put, RestController::patch)  for method calls of the Response struct and creates OpenApi Specs for them.
This feature should be seen as experimental.

The example/openapi as well as rwf-tests includes usage samples. 