### PR TITLE
Correct and expand the WebSockets documentation

### DIFF
--- a/docs/docs/controllers/websockets.md
+++ b/docs/docs/controllers/websockets.md
@@ -28,7 +28,7 @@ The trait has two methods of interest: the first handles new WebSocket connectio
 incoming messages from the client.
 
 ```rust
-use rwf::controller::Websocket;
+use rwf::controller::WebsocketController;
 use rwf::prelude::*;
 
 #[derive(Default, macros::WebsocketController)]
@@ -37,17 +37,17 @@ struct Echo;
 #[async_trait]
 impl WebsocketController for Echo {
     /// Run some code when a new client connects to the WebSocket server.
-    async fn handle_connection(
+    async fn client_connected(
         &self,
         client: &SessionId,
     ) -> Result<(), Error> {
-        log::info!("Client {:?} connected to the echo server", client);
+        println!("Client {:?} connected to the echo server", client);
 
         Ok(())
     }
 
     /// Run some code when a client sends a message to the server.
-    async fn handle_message(
+    async fn client_message(
         &self,
         client: &SessionId,
         message: Message,
@@ -113,7 +113,7 @@ use rwf::http::{Server, self};
 
 #[tokio::main]
 async fn main() -> Result<(), http::Error> {
-    let server = Server::new(vec![
+    Server::new(vec![
         route!("/websocket" => Echo),
     ])
     .launch()
@@ -131,3 +131,12 @@ const ws = new WebSocket("ws://localhost:8000/websocket");
 
 If everything works, you should see a log line in the terminal where the server is running, indicating a new
 client has joined the party.
+
+Now, send the server a message, with an event listener set up to print any messages received:
+
+```javascript
+ws.onmessage = (event) => console.log(event.data);
+ws.send("Hey there");
+```
+
+You should see `Hey there` echoed back to you on the console.


### PR DESCRIPTION
## Summary

The branch to be merged corrects some errors that prevented the WebSockets sample code from compiling.

## Changes

### Corrections

The errors corrected include the ones described in issue #77, which affect the code in the "Writing a WebSocket controller" section.

They also include an additional error in the "Starting a WebSocket server" section; the code from this section is needed to build a runnable program.

### Expansion

The branch to be merged also expands the testing instructions to confirm that the echo server is working as intended.

## Validation

I've checked my changes using the following process.

1. Start a new crate with the following `Cargo.toml`.

   ```toml
   [package]
   name = "websocket-docs-test"
   version = "0.1.0"
   edition = "2024"

   [dependencies]
   rwf = "0.2.1"
   ```

2. Copy the code from the corrected documentation sections into `src/main.rs`.
3. Start the server with `cargo run` and then follow the expanded testing instructions from the documentation.