### PR TITLE
Install Nextest correctly during continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,9 @@ jobs:
                   override: true
             - uses: Swatinem/rust-cache@v2
             - name: Install test dependencies
-              run: cargo install cargo-nextest cargo-expand
+              run: |
+                  cargo install cargo-nextest --locked
+                  cargo install cargo-expand
             - name: Run tests
               run: cargo nextest run
             - name: Run documentation tests


### PR DESCRIPTION
On the branch to be merged, the continuous integration workflow should be working again, because issue #80 has been addressed.